### PR TITLE
Return all matches from namedGroups() #7

### DIFF
--- a/src/main/java/com/google/code/regexp/MatchResult.java
+++ b/src/main/java/com/google/code/regexp/MatchResult.java
@@ -41,7 +41,7 @@ public interface MatchResult extends java.util.regex.MatchResult {
      *
      * @return the named capture groups
      */
-    public Map<String, String> namedGroups();
+    public List<Map<String, String>> namedGroups();
 
     /**
      * Returns the input subsequence captured by the given group during the

--- a/src/main/java/com/google/code/regexp/Matcher.java
+++ b/src/main/java/com/google/code/regexp/Matcher.java
@@ -269,8 +269,13 @@ public class Matcher implements MatchResult {
      * matcher and attempts to match the input against the pre-specified
      * pattern.
      *
-     * @return a map of the group named and matched values
-     * (empty if no match found)
+     * @return a list of maps, each containing name-value matches
+     * (empty if no match found).
+     *
+     * Example:
+     *   pattern:  (?<dote>\d+).(?<day>\w+)
+     *   input:    1 Sun foo bar 2 Mon foo
+     *   output:   [{"date":"1", "day":"Sun"}, {"date":"2", "day":"Mon"}]
      */
     public List<Map<String, String>> namedGroups() {
         List<Map<String, String>> result = new ArrayList<Map<String, String>>();

--- a/src/main/java/com/google/code/regexp/Matcher.java
+++ b/src/main/java/com/google/code/regexp/Matcher.java
@@ -272,14 +272,20 @@ public class Matcher implements MatchResult {
      * @return a map of the group named and matched values
      * (empty if no match found)
      */
-    public Map<String, String> namedGroups() {
-        Map<String, String> result = new LinkedHashMap<String, String>();
+    public List<Map<String, String>> namedGroups() {
+        List<Map<String, String>> result = new ArrayList<Map<String, String>>();
 
-        if (matcher.find(0)) {
+        int nextIndex = 0;
+        while (matcher.find(nextIndex)) {
+            Map<String, String> matches = new LinkedHashMap<String, String>();
+
             for (String groupName : parentPattern.groupNames()) {
                 String groupValue = matcher.group(groupIndex(groupName));
-                result.put(groupName, groupValue);
+                matches.put(groupName, groupValue);
+                nextIndex = matcher.end();
             }
+
+            result.add(matches);
         }
         return result;
     }

--- a/src/test/java/com/google/code/regexp/MatcherTest.java
+++ b/src/test/java/com/google/code/regexp/MatcherTest.java
@@ -302,7 +302,10 @@ public class MatcherTest {
         Pattern p = Pattern.compile("(a)(?<foo>b)(?:c)(?<bar>d(?<named>x))");
         Matcher m = p.matcher("abcdxyz");
 
-        Map<String, String> map = m.namedGroups();
+        List<Map<String, String>> list = m.namedGroups();
+        assertEquals(1, list.size());
+
+        Map<String, String> map = list.get(0);
         assertEquals(3, map.size());
         assertEquals("b", map.get("foo"));
         assertEquals("dx", map.get("bar"));
@@ -314,8 +317,8 @@ public class MatcherTest {
         Pattern p = Pattern.compile("(a)(?<foo>b)(?:c)(?<bar>d(?<named>x))");
         Matcher m = p.matcher("nada");
 
-        Map<String, String> map = m.namedGroups();
-        assertEquals(0, map.size());
+        List<Map<String, String>> list = m.namedGroups();
+        assertEquals(0, list.size());
     }
 
     @Test
@@ -714,5 +717,31 @@ public class MatcherTest {
         Matcher m = p.matcher("abc\\Q123\\E");
         assertTrue(m.find());
         assertEquals("123", m.group("named"));
+    }
+
+    @Test
+    public void testNamedGroupsGetsAllMatchesInSingleGroup() {
+        Pattern pattern = Pattern.compile("(?<digit>\\d)(\\w)");
+        Matcher matcher = pattern.matcher("2foo3bar4");
+
+        final List<Map<String, String>> groups = matcher.namedGroups();
+        assertEquals(2, groups.size());
+        assertEquals("2", groups.get(0).get("digit"));
+        assertEquals("3", groups.get(1).get("digit"));
+    }
+
+    @Test
+    public void testNamedGroupsGetsAllMatchesInMultipleGroups() {
+        Pattern pattern = Pattern.compile("(?<dayOfYear>\\d+).(?<dayName>\\w+)");
+        Matcher matcher = pattern.matcher("1 Sunday foo bar 2 Monday foo bar 3 Tuesday foo bar 4 Wednesday foo bar 5 Thursday foo bar 6 Friday foo bar  7 Saturday foo bar 8 Sunday foo bar 9 Monday foo bar 10 Tuesday foo bar ");
+
+        final List<Map<String, String>> groups = matcher.namedGroups();
+        final String[] DAYS = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday", "Monday", "Tuesday"};
+        assertEquals(DAYS.length, groups.size());
+
+        for (int i = 0; i < DAYS.length; i++) {
+            assertEquals(i + 1 + "", groups.get(i).get("dayOfYear"));
+            assertEquals(DAYS[i], groups.get(i).get("dayName"));
+        }
     }
 }


### PR DESCRIPTION
**BREAKING CHANGE:** Current users of `Matcher#namedGroups()` must update to the new return type.

from:

    Map<String, String> namedGroups()

to:

    List<Map<String, String>> namedGroups()

