### PR TITLE
Fix infinite loop in Matcher#namedGroups() when no groups in pattern

### DIFF
--- a/src/main/java/com/google/code/regexp/Matcher.java
+++ b/src/main/java/com/google/code/regexp/Matcher.java
@@ -280,12 +280,17 @@ public class Matcher implements MatchResult {
      */
     public List<Map<String, String>> namedGroups() {
         List<Map<String, String>> result = new ArrayList<Map<String, String>>();
+        List<String> groupNames = parentPattern.groupNames();
+
+        if (groupNames.isEmpty()) {
+            return result;
+        }
 
         int nextIndex = 0;
         while (matcher.find(nextIndex)) {
             Map<String, String> matches = new LinkedHashMap<String, String>();
 
-            for (String groupName : parentPattern.groupNames()) {
+            for (String groupName : groupNames) {
                 String groupValue = matcher.group(groupIndex(groupName));
                 matches.put(groupName, groupValue);
                 nextIndex = matcher.end();

--- a/src/test/java/com/google/code/regexp/MatcherTest.java
+++ b/src/test/java/com/google/code/regexp/MatcherTest.java
@@ -744,4 +744,14 @@ public class MatcherTest {
             assertEquals(DAYS[i], groups.get(i).get("dayName"));
         }
     }
+
+    // Specify 1 second timeout to account for potential infinite loop (Issue #9)
+    @Test(timeout=1000)
+    public void testNamedGroupsReturnsEmptyListWhenNoGroupPresent() {
+        Pattern pattern = Pattern.compile("\\d+ no groups");
+        Matcher matcher = pattern.matcher("123 no groups");
+
+        final List<Map<String, String>> groups = matcher.namedGroups();
+        assertTrue(groups.isEmpty());
+    }
 }


### PR DESCRIPTION
Fixes #9 