### PR TITLE
fix: let Matcher#namedGroups() be called multiple times

### DIFF
--- a/src/main/java/com/google/code/regexp/Matcher.java
+++ b/src/main/java/com/google/code/regexp/Matcher.java
@@ -320,7 +320,9 @@ public class Matcher implements MatchResult {
         }
 
         int nextIndex = 0;
-        while (!matcher.hitEnd() && matcher.find(nextIndex)) {
+        int lastNextIndex = 0;
+        matcher.reset();
+        while (matcher.find(nextIndex)) {
             Map<String, String> matches = new LinkedHashMap<String, String>();
 
             for (String groupName : groupNames) {
@@ -328,6 +330,11 @@ public class Matcher implements MatchResult {
                 matches.put(groupName, groupValue);
                 nextIndex = matcher.end();
             }
+
+            if (nextIndex == lastNextIndex) {
+                break;
+            }
+            lastNextIndex = nextIndex;
 
             result.add(matches);
         }

--- a/src/test/java/com/google/code/regexp/MatcherTest.java
+++ b/src/test/java/com/google/code/regexp/MatcherTest.java
@@ -763,4 +763,17 @@ public class MatcherTest {
         assertEquals(1, groups.size());
         assertEquals("bar", groups.get(0).get("foo"));
     }
+
+    // Issue #26
+    @Test
+    public void testNamedGroupsCanBeCalledMultipleTimes() {
+        final String regex = "/teamDrawer/(?<roomId>.*)";
+        final String url = "/teamDrawer/12345";
+
+        final Matcher matcher = Pattern.compile(regex).matcher(url);
+        final Integer count = matcher.namedGroups().size();
+        final Integer mapCount = matcher.namedGroups().get(0).size();
+        final String value = matcher.namedGroups().get(0).get("roomId");
+        assertEquals("12345", value);
+    }
 }


### PR DESCRIPTION
`Matcher.hitEnd()` does not actually work as expected. Stepping through shows that the underlying property never gets set, so we can't reliably use this to exit the loop in `Matcher.namedGroups()`.

This PR replaces `hitEnd()` with a check of the last match's index. If the last index is repeated, we've hit the end.

related #17
fix #26